### PR TITLE
Fix comment hyphen in wake picker section

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,7 +56,7 @@ function ensureCSS(){
   document.head.appendChild(s);
 }
 
-// -------------------- Wake‑time picker ---------------------------------
+// -------------------- Wake-time picker ---------------------------------
 function showWakePicker(){
   ensureCSS();
   const ov=document.createElement("div"); ov.className="overlay";


### PR DESCRIPTION
## Summary
- replace non-ASCII hyphen in the "Wake-time picker" comment with a standard ASCII hyphen

## Testing
- `grep -n "Wake" app.js`